### PR TITLE
recovery: Rewrite slot switch logic using bootcontrol APIs

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -105,7 +105,6 @@ cc_defaults {
         "libcrypto",
         "libcutils",
         "libfs_mgr",
-        "libhardware",
         "liblp",
         "liblog",
         "libprotobuf-cpp-lite",

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -40,10 +40,9 @@
 #include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <android-base/strings.h>
+#include <android/hardware/boot/1.0/IBootControl.h>
 #include <cutils/properties.h> /* for property_list */
 #include <fs_mgr/roots.h>
-#include <hardware/boot_control.h>
-#include <hardware/hardware.h>
 #include <ziparchive/zip_archive.h>
 
 #include "bootloader_message/bootloader_message.h"
@@ -63,6 +62,11 @@
 #include "recovery_utils/battery_utils.h"
 #include "recovery_utils/logging.h"
 #include "recovery_utils/roots.h"
+
+using android::sp;
+using android::hardware::boot::V1_0::IBootControl;
+using android::hardware::boot::V1_0::CommandResult;
+using android::hardware::boot::V1_0::Slot;
 
 static constexpr const char* COMMAND_FILE = "/cache/recovery/command";
 static constexpr const char* LAST_KMSG_FILE = "/cache/recovery/last_kmsg";
@@ -184,27 +188,21 @@ std::string get_chosen_slot(Device* device) {
 
 int set_slot(Device* device) {
   std::string slot = get_chosen_slot(device);
-  if (slot == "")
-    return 0;
-  const hw_module_t *hw_module;
-  boot_control_module_t *module;
-  int ret;
-  ret = hw_get_module("bootctrl", &hw_module);
-  if (ret != 0) {
+  CommandResult ret;
+  auto cb = [&ret](CommandResult result) { ret = result; };
+  Slot sslot = (slot == "A") ? 0 : 1;
+  sp<IBootControl> module = IBootControl::getService();
+  if (!module) {
     device->GetUI()->Print("Error getting bootctrl module.\n");
   } else {
-    module = (boot_control_module_t*) hw_module;
-    module->init(module);
-    int slot_number = 0;
-    if (slot == "B")
-      slot_number = 1;
-    if (module->setActiveBootSlot(module, slot_number))
-      device->GetUI()->Print("Error changing bootloader boot slot to %s", slot.c_str());
-    else {
+    auto result = module->setActiveBootSlot(sslot, cb);
+    if (result.isOk() && ret.success) {
       device->GetUI()->Print("Switched slot to %s.\n", slot.c_str());
+    } else {
+      device->GetUI()->Print("Error changing bootloader boot slot to %s", slot.c_str());
     }
   }
-  return ret;
+  return ret.success ? 0 : 1;
 }
 
 static bool ask_to_wipe_data(Device* device) {


### PR DESCRIPTION
Ref: https://github.com/yaap/bootable_recovery/commit/71daa409b8cace5696015a0b9df629e77956617c

Change-Id: I1eb136c81cc9246b0c9f5e52bcf6e7ba40fbc12d
[cyberknight777: Adapt to T]
Signed-off-by: Cyber Knight <cyberknight755@gmail.com>